### PR TITLE
Changing zcompdumps file location

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -58,7 +58,7 @@ fi
 
 # Save the location of the current completion dump file.
 if [ -z "$ZSH_COMPDUMP" ]; then
-  ZSH_COMPDUMP="${ZDOTDIR:-${HOME}}/.zcompdump-${SHORT_HOST}-${ZSH_VERSION}"
+  ZSH_COMPDUMP="${ZDOTDIR:-${HOME}}/.cache/zsh/.zcompdump-${SHORT_HOST}-${ZSH_VERSION}"
 fi
 
 if [[ $ZSH_DISABLE_COMPFIX != true ]]; then


### PR DESCRIPTION
# Issue
- I don't like how the zcomp dumps are being placed in the `home` directory, so I'm adding a small change to place them in a separate directory. 

# How to use
- Make sure `~/.cache/zsh` exists